### PR TITLE
Add token span :map for fenced code blocks

### DIFF
--- a/src/nextjournal/markdown/parser.cljc
+++ b/src/nextjournal/markdown/parser.cljc
@@ -323,9 +323,9 @@ end"
       (open-node :code)
       (push-node (text-node c))
       close-node))
-(defmethod apply-token "fence" [doc {:as _token i :info c :content}]
+(defmethod apply-token "fence" [doc {:as _token i :info c :content m :map}]
   (-> doc
-      (open-node :code {} (assoc (parse-fence-info i) :info i))
+      (open-node :code {} (assoc (parse-fence-info i) :info i :map m))
       (push-node (text-node c))
       close-node))
 

--- a/test/nextjournal/markdown_test.cljc
+++ b/test/nextjournal/markdown_test.cljc
@@ -77,7 +77,8 @@ $$\\int_a^bf(t)dt$$
                       {:content [{:text "(+ 1 2 3)\n" :type :text}]
                        :info "clojure"
                        :language "clojure"
-                       :type :code}
+                       :type :code
+                       :map [4 7]}
                       {:text "\\int_a^bf(t)dt"
                        :type :block-formula}
                       {:content [{:content [{:content [{:text "one"


### PR DESCRIPTION
Adds :map from the tokenizer to final output. This is useful for referencing specific code blocks from the input.

My use-case for this is for printing pretty errors when evaluating code blocks from within Markdown.