### PR TITLE
Drop default parsing of hashtags and internal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## (Unreleased) 0.5.X
+* Support hard-breaks
+* Fix conversion to hiccup for tables with empty cells (#13)
+* Remove parsing hashtags and internal links by default
+* Fix scope of hashtags and internal links when opted-in
+
 ## 0.4.138
 * Uses the official markdown-it/footnote plugin 
 * Adds optional (post-parse) handling of footnotes as sidenotes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
 ## (Unreleased) 0.5.X
+* Disable parsing hashtags and internal links by default
+* Allow conditional application of custom tokenizers depending on parse context
+* Add arity 2 to `nextjournal.markdown/parse`
 * Support hard-breaks
 * Fix conversion to hiccup for tables with empty cells (#13)
-* Remove parsing hashtags and internal links by default
-* Fix scope of hashtags and internal links when opted-in
 
 ## 0.4.138
 * Uses the official markdown-it/footnote plugin 

--- a/deps.edn
+++ b/deps.edn
@@ -13,6 +13,7 @@
    :exec-fn nextjournal.clerk/build-static-app!
    :exec-args {:git/url "https://github.com/nextjournal/markdown"
                :paths ["README.md"
+                       "CHANGELOG.md"
                        "notebooks/try.clj"
                        "notebooks/pandoc.clj"
                        "notebooks/parsing_extensibility.clj"
@@ -24,7 +25,7 @@
 
   :test
   {:extra-paths ["test"]
-   :extra-deps {nubank/matcher-combinators {:mvn/version "3.5.0"}}
+   :extra-deps {nubank/matcher-combinators {:mvn/version "3.8.3"}}
    :exec-fn test-runner/run}
 
   :cljs-test

--- a/deps.edn
+++ b/deps.edn
@@ -32,7 +32,7 @@
   {:extra-paths ["test"]
    :main-opts ["-m" "shadow.cljs.devtools.cli"]
    :extra-deps {thheller/shadow-cljs {:mvn/version "2.18.0"}
-                nubank/matcher-combinators {:mvn/version "3.5.0"}}}
+                nubank/matcher-combinators {:mvn/version "3.8.3"}}}
 
   :sci
   {:extra-paths ["sci"]

--- a/notebooks/benchmarks.clj
+++ b/notebooks/benchmarks.clj
@@ -37,11 +37,15 @@
                   :handler (fn [data] {:type :losange :data data})}]
                 reference-text))
 
-(parse [{:regex #"\{\{([^\{]+)\}\}"
-         :handler (fn [m] {:type :var :text (m 1)})}
-        {:tokenizer-fn parsing-extensibility/losange-tokenizer-fn
-         :handler (fn [data] {:type :losange :data data})}]
-       reference-text)
+;; With hashtags and internal links
+(time-ms
+ (parse [md.parser/hashtag-tokenizer
+         md.parser/internal-link-tokenizer
+         {:regex #"\{\{([^\{]+)\}\}"
+          :handler (fn [m] {:type :var :text (m 1)})}
+         {:tokenizer-fn parsing-extensibility/losange-tokenizer-fn
+          :handler (fn [data] {:type :losange :data data})}]
+        reference-text))
 
 ^{::clerk/visibility {:code :hide :result :hide}}
 (comment

--- a/notebooks/parsing_extensibility.clj
+++ b/notebooks/parsing_extensibility.clj
@@ -3,7 +3,6 @@
   {:nextjournal.clerk/toc :collapsed
    :nextjournal.clerk/no-cache true}
   (:require [nextjournal.clerk :as clerk]
-            [nextjournal.clerk.viewer :as clerk.viewer]
             [nextjournal.markdown :as md]
             [nextjournal.markdown.parser :as md.parser]
             [edamame.core :as edamame]
@@ -14,25 +13,32 @@
   {:var-from-def? true
    :transform-fn (fn [{{::clerk/keys [var-from-def]} :nextjournal/value}] (clerk/html [:pre @var-from-def]))})
 
-;; With recent additions to our `nextjournal.markdown.parser` we added a tiny parsing layer on top of the tokenization provided by `markdown-it` ([n.markdown/tokenize](https://github.com/nextjournal/markdown/blob/ae2a2f0b6d7bdc6231f5d088ee559178b55c97f4/src/nextjournal/markdown.clj#L50-L52)).
+;; With recent additions to our `nextjournal.markdown.parser` we're allowing for a customizable parsing layer on top of the tokenization provided by `markdown-it` ([n.markdown/tokenize](https://github.com/nextjournal/markdown/blob/ae2a2f0b6d7bdc6231f5d088ee559178b55c97f4/src/nextjournal/markdown.clj#L50-L52)).
 ;; We're acting on the text (leaf) tokens, splitting each of those into a collection of [nodes](https://github.com/nextjournal/markdown/blob/ff68536eb15814fe81db7a6d6f11f049895a4282/src/nextjournal/markdown/parser.cljc#L5).  We'll explain how that works by means of three examples.
 ;;
 ;; ## Regex-based tokenization
 ;;
-;; A `Tokenizer` requires keys `:doc-handler` and `:tokenizer-fn` but for convenience we might provide a map
-;; with a `:regex` and a `:handler` (function of `Match` to a `Node`) and `md.parser/normalize-tokenizer` will fill in the missing keys
+;; A `Tokenizer` is a map with keys `:doc-handler` and `:tokenizer-fn`. For convenience, the function `md.parser/normalize-tokenizer` will fill in the missing keys
+;; starting from a map with a `:regex` and a `:handler`:
 
-(def regex-tokenizer
+(def internal-link-tokenizer
   (md.parser/normalize-tokenizer
    {:regex #"\[\[([^\]]+)\]\]"
     :handler (fn [match] {:type :internal-link
                           :text (match 1)})}))
 
-((:tokenizer-fn regex-tokenizer) "some [[set]] of [[wiki]] link")
+((:tokenizer-fn internal-link-tokenizer) "some [[set]] of [[wiki]] link")
 
-(md.parser/tokenize-text-node regex-tokenizer {:text "some [[set]] of [[wiki]] link"})
-;; and the whole story becomes
-(md/parse "some [[set]] of [[wiki]] link")
+(md.parser/tokenize-text-node internal-link-tokenizer {:text "some [[set]] of [[wiki]] link"})
+
+
+;; In order to opt-in of the extra tokenization above, we need to configure the document context as follows:
+(md/parse (update md.parser/empty-doc :text-tokenizers conj internal-link-tokenizer)
+          "some [[set]] of [[wiki]] link")
+
+;; We provide an internal link tokenizer as well as a hashtags tokenizer as part of the `nextjournal.markdown.parser` namespace.
+;;
+;; By default, these are not used during parsing and need to be opted-in for like explained above.
 
 ;; ## Read-based tokenization
 ;;
@@ -89,7 +95,7 @@ existing [[links]] or #tags")
 ;; the following textual example (**TODO** _rewrite parsing with a zipper state_):
 ^{::clerk/viewer show-text}
 (def text-with-meta
-  "# Example ◊(add-meta {:id \"some-id\" :class \"semantc\"})
+  "# Example ◊(add-meta {:attrs {:id \"some-id\"} :class \"semantc\"})
 In this example we're using the losange tokenizer to modify the
 document AST in conjunction with the following functions:
 * `add-meta`: looks up the parent node, merges a map in it
@@ -114,10 +120,12 @@ and adds a flag to its text.
 
 (def data
   (md.parser/parse
-   (update md.parser/empty-doc :text-tokenizers conj
-           (assoc losange-tokenizer
-                  :doc-handler (fn [doc {:keys [match]}]
-                                 (apply (eval (first match)) doc (rest match)))))
+   (-> md.parser/empty-doc
+       (dissoc :text->id+emoji-fn)
+       (update :text-tokenizers conj
+               (assoc losange-tokenizer
+                      :doc-handler (fn [doc {:keys [match]}]
+                                     (apply (eval (first match)) doc (rest match))))))
    (md/tokenize text-with-meta)))
 
 (clerk/md data)

--- a/notebooks/parsing_extensibility.clj
+++ b/notebooks/parsing_extensibility.clj
@@ -29,7 +29,7 @@
 
 ((:tokenizer-fn internal-link-tokenizer) "some [[set]] of [[wiki]] link")
 
-(md.parser/tokenize-text-node internal-link-tokenizer {:text "some [[set]] of [[wiki]] link"})
+(md.parser/tokenize-text-node internal-link-tokenizer {} {:text "some [[set]] of [[wiki]] link"})
 
 
 ;; In order to opt-in of the extra tokenization above, we need to configure the document context as follows:
@@ -83,7 +83,7 @@ existing [[links]] or #tags")
     :handler (fn [clj-data] {:type :losange
                              :data clj-data})}))
 
-(md.parser/tokenize-text-node losange-tokenizer {:text text})
+(md.parser/tokenize-text-node losange-tokenizer {} {:text text})
 
 ;; putting it all together and giving losange topmost priority wrt other tokens
 (md.parser/parse (update md.parser/empty-doc :text-tokenizers #(cons losange-tokenizer %))

--- a/notebooks/parsing_extensibility.clj
+++ b/notebooks/parsing_extensibility.clj
@@ -36,9 +36,7 @@
 (md/parse (update md.parser/empty-doc :text-tokenizers conj internal-link-tokenizer)
           "some [[set]] of [[wiki]] link")
 
-;; We provide an internal link tokenizer as well as a hashtags tokenizer as part of the `nextjournal.markdown.parser` namespace.
-;;
-;; By default, these are not used during parsing and need to be opted-in for like explained above.
+;; We provide an `internal-link-tokenizer` as well as a `hashtag-tokenizer` as part of the `nextjournal.markdown.parser` namespace. By default, these are not used during parsing and need to be opted-in for like explained above.
 
 ;; ## Read-based tokenization
 ;;

--- a/src/nextjournal/markdown.clj
+++ b/src/nextjournal/markdown.clj
@@ -45,7 +45,8 @@
 
 (defn parse
   "Turns a markdown string into a nested clojure structure."
-  [markdown-text] (-> markdown-text tokenize markdown.parser/parse))
+  ([markdown-text] (parse markdown.parser/empty-doc markdown-text))
+  ([doc markdown-text] (markdown.parser/parse doc (tokenize markdown-text))))
 
 (defn ->hiccup
   "Turns a markdown string into hiccup."

--- a/src/nextjournal/markdown.cljs
+++ b/src/nextjournal/markdown.cljs
@@ -13,7 +13,8 @@
 
 (defn parse
   "Turns a markdown string into a nested clojure structure."
-  [markdown-text] (-> markdown-text tokenize markdown.parser/parse))
+  ([markdown-text] (parse markdown.parser/empty-doc markdown-text))
+  ([doc markdown-text] (markdown.parser/parse doc (tokenize markdown-text))))
 
 (defn ->hiccup
   "Turns a markdown string into hiccup."

--- a/src/nextjournal/markdown/parser.cljc
+++ b/src/nextjournal/markdown/parser.cljc
@@ -164,11 +164,29 @@
    (-> doc
        (push-node (node type [] attrs top-level))
        (update ::path into [:content -1]))))
+
 ;; after closing a node, document ::path will point at it
 (def ppop (comp pop pop))
 (defn close-node [doc] (update doc ::path ppop))
 (defn update-current [{:as doc path ::path} fn & args] (apply update-in doc path fn args))
 
+(defn current-parent-node
+  "Given an open parsing context `doc`, returns the parent of the node which was last parsed into the document."
+  [{:as doc ::keys [path]}]
+  (assert path "A path is needed in document context to retrieve the current node: `current-parent-node` cannot be called after `parse`.")
+  (get-in doc (ppop path)))
+
+(defn current-ancestor-nodes
+  "Given an open parsing context `doc`, returns the list of ancestors of the node last parsed into the document, up to but
+   not including the top document."
+  [{:as doc ::keys [path]}]
+  (assert path "A path is needed in document context to retrieve the current node: `current-ancestor-nodes` cannot be called after `parse`.")
+  (loop [p (ppop path) ancestors []]
+    (if (seq p)
+      (recur (ppop p) (conj ancestors (get-in doc p)))
+      ancestors)))
+
+;; TODO: consider rewriting parse in terms of this zipper
 (defn ->zip [doc]
   (z/zipper (every-pred map? :type) :content
             (fn [node cs] (assoc node :content (vec cs)))
@@ -473,25 +491,38 @@ And what.
 
 (def hashtag-tokenizer
   {:regex #"(^|\B)#[\w-]+"
+   :pred #(every? (complement #{:link}) (map :type (current-ancestor-nodes %)))
    :handler (fn [match] {:type :hashtag :text (subs (match 0) 1)})})
 
 (def internal-link-tokenizer
   {:regex #"\[\[([^\]]+)\]\]"
+   :pred #(every? (complement #{:link}) (map :type (current-ancestor-nodes %)))
    :handler (fn [match] {:type :internal-link :text (match 1)})})
+
+(comment
+  (->> "# Hello #Fishes
+
+> what about #this
+
+_this #should be a tag_, but this [_actually #foo shouldnt_](/bar/) is not."
+       nextjournal.markdown/tokenize
+       (parse (update empty-doc :text-tokenizers conj hashtag-tokenizer))))
+
 
 (defn normalize-tokenizer
   "Normalizes a map of regex and handler into a Tokenizer"
-  [{:as tokenizer :keys [doc-handler handler regex tokenizer-fn]}]
+  [{:as tokenizer :keys [doc-handler pred handler regex tokenizer-fn]}]
   (assert (and (or doc-handler handler) (or regex tokenizer-fn)))
   (cond-> tokenizer
     (not doc-handler) (assoc :doc-handler (fn [doc {:keys [match]}] (push-node doc (handler match))))
-    (not tokenizer-fn) (assoc :tokenizer-fn (partial re-idx-seq regex))))
+    (not tokenizer-fn) (assoc :tokenizer-fn (partial re-idx-seq regex))
+    (not pred) (assoc :pred (constantly true))))
 
-(defn tokenize-text-node [{:as tkz :keys [tokenizer-fn doc-handler]} {:as node :keys [text]}]
+(defn tokenize-text-node [{:as tkz :keys [tokenizer-fn pred doc-handler]} doc {:as node :keys [text]}]
   ;; TokenizerFn -> HNode -> [HNode]
   (assert (and (fn? tokenizer-fn) (fn? doc-handler) (string? text))
           {:text text :tokenizer tkz})
-  (let [idx-seq (tokenizer-fn text)]
+  (let [idx-seq (when (pred doc) (tokenizer-fn text))]
     (if (seq idx-seq)
       (let [text-hnode (fn [s] (assoc (text-node s) :doc-handler push-node))
             {:keys [nodes remaining-text]}
@@ -516,24 +547,22 @@ And what.
           doc
           (reduce (fn [nodes tokenizer]
                     (mapcat (fn [{:as node :keys [type]}]
-                              (if (= :text type) (tokenize-text-node tokenizer node) [node]))
+                              (if (= :text type) (tokenize-text-node tokenizer doc node) [node]))
                             nodes))
                   [{:type :text :text content :doc-handler push-node}]
                   text-tokenizers)))
 
 (comment
   (def mustache (normalize-tokenizer {:regex #"\{\{([^\{]+)\}\}" :handler (fn [m] {:type :eval :text (m 1)})}))
-  (tokenize-text-node mustache {:text "{{what}} the {{hellow}}"})
+  (tokenize-text-node mustache {} {:text "{{what}} the {{hellow}}"})
   (apply-token (assoc empty-doc :text-tokenizers [mustache])
                {:type "text" :content "foo [[bar]] dang #hashy taggy [[what]] #dangy foo [[great]] and {{eval}} me"})
-
-  (nextjournal.markdown/parse "foo [[bar]] dang #hashy taggy [[what]] #dangy foo [[great]]" )
 
   (parse (assoc empty-doc
                 :text-tokenizers
                 [(normalize-tokenizer {:regex #"\{\{([^\{]+)\}\}"
-                                       :doc-handler (fn [doc {[_ meta] :match}]
-                                                      (update-in doc (pop (pop (::path ddoc))) assoc :meta meta))})])
+                                       :doc-handler (fn [{:as doc ::keys [path]} {[_ meta] :match}]
+                                                      (update-in doc (ppop path) assoc :meta meta))})])
          (nextjournal.markdown/tokenize "# Title {{id=heading}}
 * one
 * two")))

--- a/src/nextjournal/markdown/parser.cljc
+++ b/src/nextjournal/markdown/parser.cljc
@@ -129,7 +129,6 @@
 
 ;; leaf nodes
 (defn text-node [text] {:type :text :text text})
-(defn tag-node [text] {:type :hashtag :text text})
 (defn formula [text] {:type :formula :text text})
 (defn block-formula [text] {:type :block-formula :text text})
 (defn footnote-ref [ref label] (cond-> {:type :footnote-ref :ref ref} label (assoc :label label)))

--- a/src/nextjournal/markdown/parser.cljc
+++ b/src/nextjournal/markdown/parser.cljc
@@ -471,11 +471,13 @@ And what.
 ;;    TokenizerFn :: String -> [IndexedMatch]
 ;;    DocHandler :: Doc -> {:match :: Match} -> Doc
 
-(def text-tokenizers
-  [{:regex #"(^|\B)#[\w-]+"
-    :handler (fn [match] {:type :hashtag :text (subs (match 0) 1)})}
-   {:regex #"\[\[([^\]]+)\]\]"
-    :handler (fn [match] {:type :internal-link :text (match 1)})}])
+(def hashtag-tokenizer
+  {:regex #"(^|\B)#[\w-]+"
+   :handler (fn [match] {:type :hashtag :text (subs (match 0) 1)})})
+
+(def internal-link-tokenizer
+  {:regex #"\[\[([^\]]+)\]\]"
+   :handler (fn [match] {:type :internal-link :text (match 1)})})
 
 (defn normalize-tokenizer
   "Normalizes a map of regex and handler into a Tokenizer"
@@ -580,7 +582,7 @@ And what.
                 :toc {:type :toc}
                 :footnotes []
                 ::path [:content -1] ;; private
-                :text-tokenizers text-tokenizers})
+                :text-tokenizers []})
 
 (defn parse
   "Takes a doc and a collection of markdown-it tokens, applies tokens to doc. Uses an emtpy doc in arity 1."
@@ -588,7 +590,10 @@ And what.
   ([doc tokens] (-> doc
                     (update :text-tokenizers (partial map normalize-tokenizer))
                     (apply-tokens tokens)
-                    (dissoc ::path :text-tokenizers))))
+                    (dissoc ::path
+                            ::id->index
+                            :text-tokenizers
+                            :text->id+emoji-fn))))
 
 (comment
 

--- a/src/nextjournal/markdown/parser.cljc
+++ b/src/nextjournal/markdown/parser.cljc
@@ -520,7 +520,7 @@ _this #should be a tag_, but this [_actually #foo shouldnt_](/bar/) is not."
 
 (defn tokenize-text-node [{:as tkz :keys [tokenizer-fn pred doc-handler]} doc {:as node :keys [text]}]
   ;; TokenizerFn -> HNode -> [HNode]
-  (assert (and (fn? tokenizer-fn) (fn? doc-handler) (string? text))
+  (assert (and (fn? tokenizer-fn) (fn? doc-handler) (fn? pred) (string? text))
           {:text text :tokenizer tkz})
   (let [idx-seq (when (pred doc) (tokenizer-fn text))]
     (if (seq idx-seq)

--- a/test/nextjournal/markdown_test.cljc
+++ b/test/nextjournal/markdown_test.cljc
@@ -4,25 +4,12 @@
             [matcher-combinators.standalone :as standalone]
             [matcher-combinators.matchers :as m]
             [nextjournal.markdown :as md]
+            [matcher-combinators.ansi-color]
             [nextjournal.markdown.parser :as md.parser]
             [nextjournal.markdown.transform :as md.transform]))
 
-#?(:cljs
-   ;; FIXME: in matcher-combinators (should probably use a simple `:fail` dispatch instead of `:matcher-combinators/mismatch`)
-   ;; mismatch are currently ignored by shadow both browser and node tests
-   (defmethod t/report [:cljs-test-display.core/default :matcher-combinators/mismatch] [m]
-     ;; Shadow browser tests
-     (when (exists? js/document)
-       (cljs-test-display.core/add-fail-node! m))
-
-     (t/inc-report-counter! :fail)
-     (println "\nFAIL in" (t/testing-vars-str m))
-     (when (seq (:testing-contexts (t/get-current-env)))
-       (println (t/testing-contexts-str)))
-     (when-let [message (:message m)]
-       (println message))
-     (println "mismatch:")
-     (println (:markup m))))
+;; com.bhauman/cljs-test-display doesn't play well with ANSI codes
+(matcher-combinators.ansi-color/disable!)
 
 (def markdown-text
   "# 🎱 Hello
@@ -41,6 +28,14 @@ $$\\int_a^bf(t)dt$$
 
 [link]:/path/to/something
 ")
+
+(defn parse-internal-links [text]
+  (md/parse (update md.parser/empty-doc :text-tokenizers conj md.parser/internal-link-tokenizer)
+            text))
+
+(defn parse-hashtags [text]
+  (md/parse (update md.parser/empty-doc :text-tokenizers conj md.parser/hashtag-tokenizer)
+            text))
 
 (deftest parse-test
   (testing "ingests markdown returns nested nodes"
@@ -109,7 +104,7 @@ $$\\int_a^bf(t)dt$$
                                   :type :internal-link}
                                  {:text " link"
                                   :type :text}]}]}
-           (md/parse "a [[wikistyle]] link")))
+                (parse-internal-links "a [[wikistyle]] link")))
 
     (is (match? {:type :doc
             :title "a wikistyle link in title"
@@ -131,7 +126,7 @@ $$\\int_a^bf(t)dt$$
                                          :type :text}]
                               :heading-level 1
                               :path [:content 0]}]}}
-           (md/parse "# a [[wikistyle]] link in title")))
+                (parse-internal-links "# a [[wikistyle]] link in title")))
 
     (is (match? {:type :doc
             :toc {:type :toc}
@@ -156,7 +151,7 @@ $$\\int_a^bf(t)dt$$
                                   :content [{:type :plain
                                              :content [{:text "pending"
                                                         :type :text}]}]}]}]}
-           (md/parse "- [x] done [[linkme]] to
+           (parse-internal-links "- [x] done [[linkme]] to
 - [ ] pending
 - [ ] pending")))))
 
@@ -377,7 +372,7 @@ rupt me when I'm writing."))))
                                          :type :text}]
                               :heading-level 1
                               :path [:content 0]}]}}
-           (md/parse "# Hello Tags
+           (parse-hashtags "# Hello Tags
 par with #really_nice #useful-123 tags
 "))))
 
@@ -394,9 +389,10 @@ par with #really_nice #useful-123 tags
               {:href "/tags/useful-123"}
               "#useful-123"]
              " tags"]]
-           (md/->hiccup "# Hello Tags
+           (md.transform/->hiccup
+            (parse-hashtags "# Hello Tags
 par with #really_nice #useful-123 tags
-")))))
+"))))))
 
 
 (deftest tight-vs-loose-lists

--- a/test/nextjournal/markdown_test.cljc
+++ b/test/nextjournal/markdown_test.cljc
@@ -376,6 +376,43 @@ rupt me when I'm writing."))))
 par with #really_nice #useful-123 tags
 "))))
 
+  (testing "Should not parse hashtags within link text"
+    (is (match? {:type :doc
+                 :content [{:attrs {:id "hello-fishes"}
+                       :content [{:text "Hello "
+                                  :type :text}
+                                 {:text "Fishes"
+                                  :type :hashtag}]
+                       :heading-level 1
+                       :type :heading}
+                      {:content [{:content [{:text "what about "
+                                             :type :text}
+                                            {:text "this"
+                                             :type :hashtag}
+                                            {:type :softbreak}
+                                            {:content [{:text "this "
+                                                        :type :text}
+                                                       {:text "should"
+                                                        :type :hashtag}
+                                                       {:text " be a tag"
+                                                        :type :text}]
+                                             :type :em}
+                                            {:text ", but this "
+                                             :type :text}
+                                            {:attrs {:href "/bar/"}
+                                             :content [{:content [{:text "actually #foo shouldnt"
+                                                                   :type :text}]
+                                                        :type :em}]
+                                             :type :link}
+                                            {:text " is not."
+                                             :type :text}]
+                                  :type :paragraph}]
+                       :type :blockquote}]}
+                (parse-hashtags
+                 "# Hello #Fishes
+> what about #this
+_this #should be a tag_, but this [_actually #foo shouldnt_](/bar/) is not."))))
+
   (testing "rendering tags"
     (is (= [:div
             [:h1 {:id "hello-tags"} "Hello Tags"]


### PR DESCRIPTION
This changes the default behaviour of `nextjournal.markdown/parse` with respect to custom text tokenization: hashtags e.g `#tag` and internal links `[[link]` are not parsed by default  any longer. Users can opt-in of them by:

```clj

(md/parse (update md.parser/empty-doc :text-tokenizers conj 
                  md.parser/internal-link-tokenizer 
                  md.parser/hashtag-tokenizer)
          "some [[set]] of [[wiki]] links with #hashtags")
;; => 
=>
{:type :doc,
 :content [{:type :paragraph,
            :content [{:type :text, :text "some "}
                      {:type :internal-link, :text "set"}
                      {:type :text, :text " of "}
                      {:type :internal-link, :text "wiki"}
                      {:type :text, :text " links with "}
                      {:type :hashtag, :text "hashtags"}]}],
 :toc {:type :toc},
 :footnotes []}
```

There has never been an actual agreement, what exactly hashtags and internal links should have linked to, when transformed into hiccup.

We allow to add a predicate to specify in which situation a tokenizer should be applied, see:
https://github.com/nextjournal/markdown/blob/f1e71e08217aa587493916406b0795d733bb2c73/src/nextjournal/markdown/parser.cljc#L492-L495

