### PR TITLE
Fix graaljs multithreaded access

### DIFF
--- a/src/nextjournal/markdown.clj
+++ b/src/nextjournal/markdown.clj
@@ -26,6 +26,20 @@
 
 (def ^Context ctx (.build context-builder))
 
+(def CTXLock (Object.))
+;; Avoid multithreading access to context
+;; - https://www.graalvm.org/latest/reference-manual/js/Multithreading/#multithreading-with-java-and-javascript
+;; - https://github.com/oracle/graaljs/blob/1d96acfa10cbea9e27e78800c2b82cdbad262791/graal-js/src/com.oracle.truffle.js.test.threading/src/com/oracle/truffle/js/test/threading/ConcurrentAccess.java#L173-L240
+
+(defmacro with-context-enter [c & body]
+  `(try (.enter ~c) ~@body (finally (.leave ~c))))
+
+(defmacro with-context-lock [c & body]
+  `(locking CTXLock (with-context-enter ~c ~@body)))
+
+#_(macroexpand '(with-context-lock ctx
+                  (.execute bla)))
+
 (def ^Value MD-imports
   ;; Contructing a `java.io.Reader` first to work around a bug with graal on windows
   ;; see https://github.com/oracle/graaljs/issues/534 and https://github.com/nextjournal/viewers/pull/33
@@ -33,14 +47,16 @@
                    io/input-stream
                    io/reader
                    (as-> r (Source/newBuilder "js" ^Reader r "markdown.mjs")))]
-    (.. ctx
-        (eval (.build source))
-        (getMember "default"))))
+    (with-context-enter ctx
+      (.. ctx
+          (eval (.build source))
+          (getMember "default")))))
 
 (def ^Value tokenize-fn (.getMember MD-imports "tokenizeJSON"))
 
 (defn tokenize [markdown-text]
-  (let [^Value tokens-json (.execute tokenize-fn (to-array [markdown-text]))]
+  (let [^Value tokens-json (with-context-lock ctx
+                             (.execute tokenize-fn (to-array [markdown-text])))]
     (json/read-str (.asString tokens-json) :key-fn keyword)))
 
 (defn parse

--- a/test/nextjournal/markdown/multi_threading_test.clj
+++ b/test/nextjournal/markdown/multi_threading_test.clj
@@ -1,0 +1,16 @@
+(ns nextjournal.markdown.multi-threading-test
+  (:require [clojure.test :as t :refer [deftest testing is]]
+            [nextjournal.markdown :as md]))
+
+(deftest multithreading
+  (let [!exs (atom [])
+        proc (fn []
+               (try (md/tokenize (slurp "notebooks/reference.md"))
+                    (catch IllegalStateException e
+                      (swap! !exs conj e))))
+        t1 (new Thread proc)
+        t2 (new Thread proc)]
+
+    (.start t1) (.start t2)
+    (.join t1) (.join t2)
+    (is (zero? (count @!exs)))))

--- a/test/test_runner.clj
+++ b/test/test_runner.clj
@@ -1,8 +1,11 @@
 (ns test-runner
   (:require [clojure.test]
-            [nextjournal.markdown-test]))
+            [nextjournal.markdown-test]
+            [nextjournal.markdown.multi-threading-test]))
 
 (defn run [_]
   (let [{:keys [fail error]} (clojure.test/run-all-tests #"nextjournal\.markdown.*-test")]
     (when (< 0 (+ fail error))
       (System/exit 1))))
+
+#_(clojure.test/run-all-tests #"nextjournal\.markdown.*-test")


### PR DESCRIPTION
Parsing markdown from different threads leads to known exceptions like

```
java.lang.IllegalStateException: Multi-threaded access requested by thread Thread[http-nio-8778-exec-1,5,main] but is not allowed for language(s) js.
```

this is an attempt to properly lock graaljs contexts following examples in

https://www.graalvm.org/latest/reference-manual/js/Multithreading/#multithreading-with-java-and-javascript

🛑 This needs java version 17 or higher (see CI)