### PR TITLE
Bump Graal js language to support Java 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 🔧 Install java
         uses: actions/setup-java@v1
         with:
-          java-version: '11.0.7'
+          java-version: '17'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master
@@ -77,7 +77,7 @@ jobs:
       - name: 🔧 Install java
         uses: actions/setup-java@v1
         with:
-          java-version: '11.0.7'
+          java-version: '17'
 
       - name: 🔧 Install clojure
         uses: DeLaGuardo/setup-clojure@master

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,18 @@
 {:paths ["src" "resources"]
  :deps {applied-science/js-interop {:mvn/version "0.3.3"}
         org.clojure/data.json {:mvn/version "2.4.0"}
-        org.graalvm.js/js {:mvn/version "21.3.2.1"}}
+
+        ;; recommended graal polyglot dependency setup as of graal JDK 23
+        ;; https://www.graalvm.org/latest/reference-manual/embed-languages/#dependency-setup
+        ;; (and example https://github.com/graalvm/polyglot-embedding-demo/blob/main/pom.xml)
+        ;; 1) org.graalvm.polyglot/polyglot
+        ;; 2) org.graalvm.polyglot/js
+        ;; ---
+        ;; 2) is a maven artifact of type 'pom' not supported by clojure deps, its pom points at
+        org.graalvm.js/js-language {:mvn/version "24.0.0"}
+        ;; 1) is a dep of org.graalvm.js/js-language
+        }
+
 
  :aliases
  {:nextjournal/clerk

--- a/src/nextjournal/markdown.clj
+++ b/src/nextjournal/markdown.clj
@@ -18,7 +18,6 @@
     ;; matching the poliglot library versions specified in deps.edn
     (.out System/out)
     (.err System/err)
-    (.allowIO true)
     (.allowExperimentalOptions true)
     (.allowAllAccess true)
     (.allowNativeAccess true)


### PR DESCRIPTION
Specifically with truffle api library dropping `sun.misc.Unsafe` which is no longer present in Java 22: 

* https://github.com/oracle/graal/pull/7510
* https://bugs.openjdk.org/browse/JDK-8316160

Closes #23.

🚧 This will probably not be merged, as we'd lose support of Java 11. We're trying to drop Graal polyglot (#25) for the clj side of things.