### PR TITLE
Add default renderers for html nodes pointing at the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-...
+- Point at the README from the default `:html-block` and `:html-inline` renderers instead of reporting an unknown node type [#69](https://github.com/nextjournal/markdown/issues/69)
 
 ## 0.7.225
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The following options are available that affect parsing:
 
 ### HTML blocks and HTML inlines
 
-Typically you'd want to customize the rendering of `:html-inline` and `:html` since these need to be rendered to raw strings:
+There is no default renderer for `:html-inline` and `:html-block`, since emitting raw strings is left to the consumer. Supply your own:
 
 ``` clojure
 (require '[hiccup2.core :as hiccup])
@@ -147,6 +147,20 @@ Typically you'd want to customize the rendering of `:html-inline` and `:html` si
 
 #_#_=>
 "<div><img src=\"...\"/></div>"
+```
+
+Per CommonMark, an HTML block ends at the first blank line, and everything up to that point stays raw. Put a blank line after the opening tag to have the contents parsed as markdown:
+
+``` clojure
+(str (hiccup/html (md/->hiccup renderers "<aside>\n\n*emphasis*\n\n</aside>")))
+
+#_#_=>
+"<div><aside><p><em>emphasis</em></p></aside></div>"
+
+(str (hiccup/html (md/->hiccup renderers "<aside>\n*emphasis*\n\n</aside>")))
+
+#_#_=>
+"<div><aside>\n*emphasis*</aside></div>"
 ```
 
 ## Transforming to other targets

--- a/src/nextjournal/markdown/impl.cljs
+++ b/src/nextjournal/markdown/impl.cljs
@@ -257,13 +257,6 @@ _this #should be a tag_, but this [_actually #foo shouldnt_](/bar/) is not."
 (defmethod apply-token "html_block" [doc token]
   (-> doc (u/update-current-loc z/append-child {:type :html-block :content [(text-node (.-content token))]})))
 
-;; html
-(defmethod apply-token "html_inline" [doc token]
-  (-> doc (u/update-current-loc z/append-child {:type :html-inline :content [(text-node (.-content token))]})))
-
-(defmethod apply-token "html_block" [doc token]
-  (-> doc (u/update-current-loc z/append-child {:type :html-block :content [(text-node (.-content token))]})))
-
 ;; endregion
 
 ;; region data builder api

--- a/src/nextjournal/markdown/transform.cljc
+++ b/src/nextjournal/markdown/transform.cljc
@@ -72,6 +72,12 @@ a paragraph
                                      (seq content) (conj [:span.title {:data-level heading-level} (:id node)])
                                      (seq children) (conj (into [:ul] (map (partial ->hiccup ctx)) children)))))))))
 
+;; emitting raw HTML unescaped is left to the consumer
+(defn- missing-html-renderer [_ctx {:keys [type]}]
+  [:span.message.red
+   [:strong (str "No default renderer for '" type "'.")]
+   " See https://github.com/nextjournal/markdown#html-blocks-and-html-inlines"])
+
 (def default-hiccup-renderers
   {:doc (partial into-markup [:div])
    :heading (fn [ctx {:as node :keys [attrs]}] (-> (heading-markup node) (conj attrs) (into-markup ctx node)))
@@ -82,6 +88,10 @@ a paragraph
    :hashtag (fn [_ {:keys [text]}] [:a.tag {:href (str "/tags/" text)} (str "#" text)]) ;; TODO: make it configurable
    :blockquote (partial into-markup [:blockquote])
    :ruler (constantly [:hr])
+
+   ;; html
+   :html-block missing-html-renderer
+   :html-inline missing-html-renderer
 
    ;; by default we always wrap images in paragraph to restore compliance with commonmark
    :image (fn [{:as _ctx ::keys [parent]} {:as node :keys [attrs]}]

--- a/test/nextjournal/markdown_test.cljc
+++ b/test/nextjournal/markdown_test.cljc
@@ -1089,7 +1089,25 @@ Bye") :content)))
 
 line
 
-link</a>")))))))
+link</a>"))))))
+  (testing "default renderers point at the README instead of failing with an unknown type"
+    (is (match? [:div
+                 [:span.message.red
+                  [:strong "No default renderer for ':html-block'."]
+                  #".*markdown#html-blocks-and-html-inlines"]
+                 [:p [:em "foo"]]
+                 [:span.message.red
+                  [:strong "No default renderer for ':html-block'."]
+                  #".*markdown#html-blocks-and-html-inlines"]]
+                (md/->hiccup "<del>\n\n*foo*\n\n</del>"))))
+  (testing "an html block ends at the first blank line, https://spec.commonmark.org/0.30/#example-167"
+    (is (match? [{:type :html-block :content [{:text #"<del>\s?"}]}
+                 {:type :paragraph :content [{:type :em}]}
+                 {:type :html-block :content [{:text #"</del>\s?"}]}]
+                (:content (md/parse "<del>\n\n*foo*\n\n</del>"))))
+    (is (match? [{:type :html-block :content [{:text #"<del>\n\*foo\*\s?"}]}
+                 {:type :html-block :content [{:text #"</del>\s?"}]}]
+                (:content (md/parse "<del>\n*foo*\n\n</del>"))))))
 
 (deftest disable-custom-extensions-test
   (is (= {:toc {:type :toc},


### PR DESCRIPTION
Addresses #69.

Parsing was already CommonMark compliant. `<del>\n\n*foo*\n\n</del>` (https://spec.commonmark.org/0.30/#example-167) parses to html-block, paragraph, html-block, and the `<aside>` case in the issue matches what markdown-it produces. What made HTML look broken is that `default-hiccup-renderers` had no entry for `:html-block` and `:html-inline`, so `->hiccup` fell through to the generic "Unknown type" span.

- Default renderers for `:html-block` and `:html-inline` that say there is no default renderer and link to the README section.
- README: fix the `:html` typo, and document that an HTML block ends at the first blank line.
- Tests for the new message and for example 167.
- Drop a duplicated pair of `html_inline` / `html_block` defmethods in `impl.cljs`.

Rendering raw HTML by default is still not the behaviour, since that means unescaped passthrough.
